### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v5
-    
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7  # v6.10.9
         with:
           start: docker compose up
           wait-on: 'http://localhost:4567'


### PR DESCRIPTION
# Summary

- Pin `actions/checkout` from `@v5` to commit SHA (v6.0.2)
- Pin `cypress-io/github-action` from `@v6` to commit SHA (v6.10.9)