### PR TITLE
feat: add nb translations for guest-cta strings

### DIFF
--- a/patches/nodebb/public/language/nb/topic.json
+++ b/patches/nodebb/public/language/nb/topic.json
@@ -1,5 +1,5 @@
 {
-    "guest-cta.title": "Hei! Det ser ut som du er interessert i dette innlegget, men du har ingen konto ennå.",
-    "guest-cta.message": "Lei av å scrolle gjennom de samme innleggene hver gang du er innom? Når du registrerer deg, kommer du alltid tilbake til akkurat der du var sist, og kan velge å bli varslet om nye svar (enten via e-post eller push-varsel). Du vil også kunne lagre bokmerker og gi innlegg en stemme opp for å vise andre medlemmer at du setter pris på dem.",
+    "guest-cta.title": "Hei! Det ser ut til at du er interessert i denne tråden, men du har ingen konto ennå.",
+    "guest-cta.message": "Lei av å skrolle gjennom de samme innleggene hver gang du er innom? Når du registrerer deg, kommer du alltid tilbake til akkurat der du var sist, og kan velge å bli varslet om nye svar (enten via e-post eller push-varsel). Du vil også kunne lagre bokmerker og gi innlegg en stemme opp for å vise andre medlemmer at du setter pris på dem.",
     "guest-cta.closing": "Med ditt bidrag kan dette innlegget bli enda bedre 💗"
 }

--- a/patches/nodebb/public/language/nb/topic.json
+++ b/patches/nodebb/public/language/nb/topic.json
@@ -1,0 +1,5 @@
+{
+    "guest-cta.title": "Hei! Det ser ut som du er interessert i dette innlegget, men du har ingen konto ennå.",
+    "guest-cta.message": "Lei av å scrolle gjennom de samme innleggene hver gang du er innom? Når du registrerer deg, kommer du alltid tilbake til akkurat der du var sist, og kan velge å bli varslet om nye svar (enten via e-post eller push-varsel). Du vil også kunne lagre bokmerker og gi innlegg en stemme opp for å vise andre medlemmer at du setter pris på dem.",
+    "guest-cta.closing": "Med ditt bidrag kan dette innlegget bli enda bedre 💗"
+}

--- a/patches/nodebb/public/language/nb/topic.json
+++ b/patches/nodebb/public/language/nb/topic.json
@@ -1,5 +1,5 @@
 {
     "guest-cta.title": "Hei! Det ser ut til at du er interessert i denne tråden, men du har ingen konto ennå.",
     "guest-cta.message": "Lei av å skrolle gjennom de samme innleggene hver gang du er innom? Når du registrerer deg, kommer du alltid tilbake til akkurat der du var sist, og kan velge å bli varslet om nye svar (enten via e-post eller push-varsel). Du vil også kunne lagre bokmerker og gi innlegg en stemme opp for å vise andre medlemmer at du setter pris på dem.",
-    "guest-cta.closing": "Med ditt bidrag kan dette innlegget bli enda bedre 💗"
+    "guest-cta.closing": "Med ditt bidrag kan denne tråden bli enda bedre 💗"
 }


### PR DESCRIPTION
# Summary

- Add patches/nodebb/public/language/nb/topic.json with Norwegian translations
- Translates guest-cta.title, guest-cta.message, and guest-cta.closing
- Overrides upstream English fallback shown to logged-out visitors on topic pages